### PR TITLE
Update romana-np-frontend-to-backend.yml

### DIFF
--- a/net_lab/romana-np-frontend-to-backend.yml
+++ b/net_lab/romana-np-frontend-to-backend.yml
@@ -13,9 +13,5 @@ spec:
       matchLabels:
        romanaSegment: frontend
    ports:
-    - protocol: tcp
+    - protocol: TCP
       port: 80
-    - protocol: icmp
-      port: 0
-    - protocol: icmp
-      port: 8


### PR DESCRIPTION
Got this when running: kubectl create -f romana-np-frontend-to-backend.yml 

The NetworkPolicy "pol1" is invalid:
* spec.ingress[0].ports[0].protocol: Unsupported value: "tcp": supported values: TCP, UDP
* spec.ingress[0].ports[1].protocol: Unsupported value: "icmp": supported values: TCP, UDP
* spec.ingress[0].ports[1].port: Invalid value: 0: must be between 1 and 65535, inclusive
* spec.ingress[0].ports[2].protocol: Unsupported value: "icmp": supported values: TCP, UDP